### PR TITLE
taker: eventually blind

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A decentralized exchange for Liquid transactions.
 
 ## Flow
 
-NOTE: for now assume all assets are unblinded.
+NOTE: for now assume all maker's inputs and outputs are unblinded.
 
 Maker wants to propose to exchange amount `x` of asset `A` for amount `y` of
 asset `B`.
@@ -89,10 +89,6 @@ spending the input proposed as a trade and invalidating the proposal.
 ## Possible improvements:
 
 - Handle L-BTC as a trading asset.
-- Rather than requiring all inputs to be unblinded, only require that the maker 
-  inputs and outputs are unblinded. Taker may blind its inputs and outputs.
-  This does not require the maker to include extra data other that the 
-  incomplete transaction.
 - Rather than requiring all maker inputs and outputs to be unblinded, only
   require that its inputs are unblinded. This requires that the maker includes
   some extra information, so that the taker can blind the whole transaction.

--- a/taker-cli.py
+++ b/taker-cli.py
@@ -11,6 +11,9 @@ b2h_rev = lambda b : wally.hex_from_bytes(b[::-1])
 def btc2sat(btc):
     return round(btc * 10**8)
 
+def sat2btc(sat):
+    return round(sat * 10**-8, 8)
+
 # adapted from https://github.com/Blockstream/liquid_multisig_issuance 
 class RPCHost(object):
     def __init__(self, url):
@@ -59,20 +62,20 @@ def main():
     assert y_[0] == 1
     y = wally.tx_confidential_value_to_satoshi(y_)
     unspents = connection.call("listunspent")
-    utxos_B = [u for u in unspents if u["asset"] == B and u["amountblinder"] == u["assetblinder"] == "0" * 64]
+    utxos_B = [u for u in unspents if u["asset"] == B]
     assert sum(btc2sat(u["amount"]) for u in utxos_B) >= y
-    fixed_fee = 54
+    fixed_fee = 500
     FEE = connection.call("dumpassetlabels")["bitcoin"]
-    utxos_FEE = [u for u in unspents if u["asset"] == FEE and u["amountblinder"] == u["assetblinder"] == "0" * 64]
+    utxos_FEE = [u for u in unspents if u["asset"] == FEE]
     assert sum(btc2sat(u["amount"]) for u in utxos_FEE) >= fixed_fee
 
-    def add_unblinded_output(tx_, script, asset, sat):
+    def add_unblinded_output(tx_, script, asset, sat, blinding_pubkey=None):
         wally.tx_add_elements_raw_output(
             tx_,
             script,
             b'\x01' + h2b_rev(asset),
             wally.tx_confidential_value_from_satoshi(sat),
-            None, # nonce
+            blinding_pubkey, # nonce
             None, # surjection proof
             None, # range proof
             0)
@@ -94,39 +97,64 @@ def main():
             None, # pegin witness
             0)
 
-    def get_new_scriptpubkey(connection):
+    def get_new_scriptpubkey_and_blinding_pubkey(connection):
         address = connection.call("getnewaddress")
-        return h2b(connection.call("getaddressinfo", address)["scriptPubKey"])
+        info = connection.call("getaddressinfo", address)
+        scriptpubkey = h2b(info["scriptPubKey"])
+        blinding_pubkey = h2b(info["confidential_key"]) if info["confidential_key"] else None
+        return (scriptpubkey, blinding_pubkey)
+
+    input_amount_blinders = ["0" * 64]
+    input_amounts = [sat2btc(x)]
+    input_assets = [A]
+    input_asset_blinders = ["0" * 64]
 
     # add output (A, x)
-    scriptpubkey_Ax = get_new_scriptpubkey(connection)
-    add_unblinded_output(tx, scriptpubkey_Ax, A, x)
+    scriptpubkey_Ax, blinding_pubkey_Ax = get_new_scriptpubkey_and_blinding_pubkey(connection)
+    add_unblinded_output(tx, scriptpubkey_Ax, A, x, blinding_pubkey_Ax)
     # add inputs (B, y+c)
     tot_in_B = 0
     for u in utxos_B:
         add_unsigned_input(tx, u["txid"], u["vout"])
+        input_amount_blinders.append(u["amountblinder"])
+        input_amounts.append(u["amount"])
+        input_asset_blinders.append(u["assetblinder"])
+        input_assets.append(u["asset"])
         tot_in_B += btc2sat(u["amount"])
         if tot_in_B >= y:
             break
     # add change output (B, c)
     if tot_in_B > y:
-        scriptpubkey_Bchange = get_new_scriptpubkey(connection)
-        add_unblinded_output(tx, scriptpubkey_Bchange, B, tot_in_B - y)
+        scriptpubkey_Bchange, blinding_pubkey_Bchange = get_new_scriptpubkey_and_blinding_pubkey(connection)
+        add_unblinded_output(tx, scriptpubkey_Bchange, B, tot_in_B - y, blinding_pubkey_Bchange)
     # add inputs (FEE, fixed_fee+c)
     tot_in_FEE = 0
     for u in utxos_FEE:
         add_unsigned_input(tx, u["txid"], u["vout"])
+        input_amount_blinders.append(u["amountblinder"])
+        input_amounts.append(u["amount"])
+        input_asset_blinders.append(u["assetblinder"])
+        input_assets.append(u["asset"])
         tot_in_FEE += btc2sat(u["amount"])
         if tot_in_FEE >= fixed_fee:
             break
     # add change output (FEE, c)
     if tot_in_FEE > fixed_fee:
-        scriptpubkey_FEEchange = get_new_scriptpubkey(connection)
-        add_unblinded_output(tx, scriptpubkey_FEEchange, FEE, tot_in_FEE - fixed_fee)
+        scriptpubkey_FEEchange, blinding_pubkey_FEEchange = get_new_scriptpubkey_and_blinding_pubkey(connection)
+        add_unblinded_output(tx, scriptpubkey_FEEchange, FEE, tot_in_FEE - fixed_fee, blinding_pubkey_FEEchange)
     # add output for fee
     add_unblinded_output(tx, None, FEE, fixed_fee)
 
     tx_hex = wally.tx_to_hex(tx, wally.WALLY_TX_FLAG_USE_WITNESS | wally.WALLY_TX_FLAG_USE_ELEMENTS)
+    tx_hex = connection.call(
+        "rawblindrawtransaction",
+        tx_hex,
+        input_amount_blinders,
+        input_amounts,
+        input_assets,
+        input_asset_blinders
+    )
+
     ret = connection.call("signrawtransactionwithwallet", tx_hex)
     assert ret["complete"]
     tx_hex = ret["hex"]


### PR DESCRIPTION
Include blinded utxos when selecting inputs.
Blind the added outputs.

If the taker has only blinded utxos and uses confidential
addresses, the result transaction will have 1 input and 2 outputs
unblinded (the ones from the maker and the fee output) while the
remaining inputs and outputs will be blinded.