### PR TITLE
taker: set nonce also if output was already blinded

### DIFF
--- a/taker-cli.py
+++ b/taker-cli.py
@@ -102,10 +102,9 @@ def rawblindrawtransaction(tx_hex,
             asset, output_abf, output_generator, os.urandom(32),
             input_assets_concat, input_abfs_concat, input_ags_concat)
 
-        if not given:
-            wally.tx_set_output_asset(tx, out_idx, output_generator)
-            wally.tx_set_output_value(tx, out_idx, output_value_commitment)
-            wally.tx_set_output_nonce(tx, out_idx, eph_key_pub)
+        wally.tx_set_output_asset(tx, out_idx, output_generator)
+        wally.tx_set_output_value(tx, out_idx, output_value_commitment)
+        wally.tx_set_output_nonce(tx, out_idx, eph_key_pub)
         wally.tx_set_output_surjectionproof(tx, out_idx, surjectionproof)
         wally.tx_set_output_rangeproof(tx, out_idx, rangeproof)
 


### PR DESCRIPTION
If the output was already blinded by the maker, the taker should
still set its blinding pubkey used to blind, so that the maker can
later use that key and its private blinding key to ublind the
output.

Also, make rawblindrawtransaction more simple and re-set asset and
amount commitments in case the output was already blinded. This
has no effect since the taker has already checked they are
identical. Moreover, if these were changed, the maker signature
would become invalid.